### PR TITLE
Update main.py

### DIFF
--- a/0x09-Shutdown/main.py
+++ b/0x09-Shutdown/main.py
@@ -8,7 +8,7 @@ def systemOffRestart():
     import os
     print("enter r for restart")
     print("enter s for shutdown")
-    print("enter any key for exot")
+    print("enter any key for exit")
 
     option = input("enter your option")
     if option == "r":


### PR DESCRIPTION
Fixed typo
11 line:
before: print("enter any key for exot")
after: print("enter any key for exit")